### PR TITLE
customer email not properly hydrated on customer object

### DIFF
--- a/src/Conversations/Threads/Support/HasCustomer.php
+++ b/src/Conversations/Threads/Support/HasCustomer.php
@@ -31,7 +31,9 @@ trait HasCustomer
         // For a Conversation the API returns a single email address along
         // with a Customer.
         if (isset($data['email'])) {
-            $emails = new Collection([$data['email']]);
+            $emails = new Collection([
+                new Email(['value' => $data['email']])
+            ]);
             $customer->setEmails($emails);
             unset($data['email']);
         }

--- a/src/Conversations/Threads/Support/HasCustomer.php
+++ b/src/Conversations/Threads/Support/HasCustomer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HelpScout\Api\Conversations\Threads\Support;
 
 use HelpScout\Api\Customers\Customer;
+use HelpScout\Api\Customers\Entry\Email;
 use HelpScout\Api\Entity\Collection;
 
 trait HasCustomer


### PR DESCRIPTION
Iterating through a conversations collection throws a RuntimeException when trying to call `extract` on a conversion object. After debugging, the emails collection is a collection of strings, instead of a collection of Entity/Email objects. The same problem might apply to other collections, like phones and websites, but haven't tested yet.